### PR TITLE
Check in compile-time for missing commands

### DIFF
--- a/include/CommandParser.h
+++ b/include/CommandParser.h
@@ -465,9 +465,9 @@ class ParsedCommandImpl
 public:
     /**
      * @brief Constructs a parsed command
-     * @param unparsedCommand A tuple with the unparsed commands
      * @param argc The argument count
      * @param argv The argument values
+     * @param commands A tuple with the unparsed commands
      * @warning Users should probably use the helper function `UnparsedCommand::parse`
      */
     ParsedCommandImpl(int argc, char* argv[], const T& commands)

--- a/include/CommandParser.h
+++ b/include/CommandParser.h
@@ -242,6 +242,13 @@ constexpr void removeAllLeadingDashes(std::string_view& view)
     view.remove_prefix(std::min(view.find_first_not_of('-'), view.size()));
 }
 
+template <typename T, typename Tuple>
+struct typeInTuple;
+
+template <typename T, typename... Types>
+struct typeInTuple<T, std::tuple<Types...>> : std::disjunction<std::is_same<T, Types>...> {
+};
+
 template <typename... Args>
 class UnparsedCommandImpl
 {
@@ -580,6 +587,10 @@ public:
     template <typename CommandType>
     [[nodiscard]] bool is(const CommandType& command) const
     {
+        static_assert(
+            details::typeInTuple<CommandType, T>::value,
+            "The specified command was not included in the tuple of commands passed when calling "
+            "UnparsedCommand::parse");
         return command.id() == commandId_;
     }
 


### PR DESCRIPTION
During compile-time ensure that the users won't be able to get the arguments or check for presence for a command that has not been provided earlier in a tuple  when parsing the commands.

Warning: This is currently not completely fool-proof as we don't take into consideration the 'id' of the command. This means that the user may forget to pass one command that happens to have the same arguments as another still.