### PR TITLE
Remove usage of `std::any`

### DIFF
--- a/include/CommandParser.h
+++ b/include/CommandParser.h
@@ -675,7 +675,7 @@ public:
 
 private:
     std::optional<std::size_t> commandIndex_ {};
-    using ParsedArgumentsType = decltype(transformUnparsedArgumentsType(T {}));
+    using ParsedArgumentsType = decltype(details::transformUnparsedArgumentsType(T {}));
     ParsedArgumentsType parsedArguments_ {};
     std::string commandId_ {};
     std::string helpPrompt_ {};


### PR DESCRIPTION
First, let's remove the reason behind it:
Instead of using void whenever referring to commands that have no
arguments, let's start using std::tuple<> and do the appropriate
refactoring.

Then, let's remove std::any since it's no longer necessary.